### PR TITLE
More editor space for alt text

### DIFF
--- a/cms/schemas/artworkImage.ts
+++ b/cms/schemas/artworkImage.ts
@@ -12,7 +12,7 @@ export const artworkImage = defineType({
     }),
     defineField({
       name: 'alt',
-      type: 'localeString',
+      type: 'localeText',
       title: 'Beskrivende tekst (for blinde)',
     }),
   ],

--- a/cms/schemas/index.ts
+++ b/cms/schemas/index.ts
@@ -7,6 +7,7 @@ import { localeString } from './localeString'
 import { localeRichText } from './localeRichText'
 import { seo } from './seo'
 import { gallery } from './gallery'
+import {localeText} from "./localeText";
 
 export const schemaTypes = [
   artwork,
@@ -17,5 +18,6 @@ export const schemaTypes = [
   aboutWorks,
   localeString,
   localeRichText,
+  localeText,
   seo,
 ]

--- a/cms/schemas/localeString.ts
+++ b/cms/schemas/localeString.ts
@@ -1,5 +1,5 @@
-import { english, norsk } from './locales'
-import { defineType, defineField } from 'sanity'
+import {english, norsk} from './locales'
+import {defineField, defineType} from 'sanity'
 
 export const localeString = defineType({
   title: 'Localized string',
@@ -18,3 +18,4 @@ export const localeString = defineType({
     }),
   ],
 })
+

--- a/cms/schemas/localeText.ts
+++ b/cms/schemas/localeText.ts
@@ -1,0 +1,20 @@
+import {defineField, defineType} from "sanity";
+import {english, norsk} from "./locales";
+
+export const localeText = defineType({
+    title: 'Localized text',
+    name: 'localeText',
+    type: 'object',
+    fields: [
+        defineField({
+            title: 'Norsk',
+            name: norsk,
+            type: 'text',
+        }),
+        defineField({
+            title: 'Engelsk',
+            name: english,
+            type: 'text',
+        }),
+    ],
+})


### PR DESCRIPTION
Alt text for artworks needs more space in the editor so we use text type instead of string.